### PR TITLE
Fix Invalid remote_state Key

### DIFF
--- a/main.py
+++ b/main.py
@@ -222,9 +222,9 @@ class WazuhCollector:
                 labels={"manager_stats_remote": "discarded_count"},
             )
             metric.add_sample(
-                "msg_sent",
-                value=remote_state["msg_sent"],
-                labels={"manager_stats_remote": "msg_sent"},
+                "queued_msgs",
+                value=remote_state["queued_msgs"],
+                labels={"manager_stats_remote": "queued_msgs"},
             )
             metric.add_sample(
                 "recv_bytes",


### PR DESCRIPTION
Currently, the program attempts to extract the value attached to a key called `msg_sent` in the returned JSON from a call to /manager/stats/remoted, which causes a crash as the key does not exist. Per [Wazuh's documentation on the remoted statistical information](https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/api.controllers.manager_controller.get_stats_remoted), the corresponding key is now named `queued_msgs`, which this PR sets the key value to.

Tested to work in a kubeadm Kubernetes environment deployed via a locally-built Docker image.