### PR TITLE
Fix last_logs Module Formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ class WazuhCollector:
             metric.add_metric(
                 labels=f'wazuh_last_logs_{log["tag"]}',
                 value={
-                    f'{log["tag"].replace("-", "_")}_{log["level"]}': f'{log["description"].strip()}'
+                    f'{log["tag"].replace("-", "_").replace(":", "_")}_{log["level"]}': f'{log["description"].strip()}'
                 },
             )
         yield metric


### PR DESCRIPTION
Presently, the last_logs tag formatter looks for `-`s to replace with `_`, but does not check for the `:` Wazuh will use in logs to delineate submodules. This causes the exporter to go down in Prometheus without triggering a liveness or readiness failure, which can disrupt services. E.g.,:
```
last_logs_info{wazuh_modulesd:syscollector_info="Starting evaluation."} 1.0
```
```
# cat example.txt | promtool check metrics
error while linting: text format parsing error in line 276: expected '=' after label name, found ':'
```

This PR adds a small check to additionally convert `:` into `_` inside of the last_log tag. Presently untested, but I'll check to see if any more of these crop up over the weekend and make additional PRs/edit this PR as I notice them.