### PR TITLE
Add missing "connection" JSON property

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,7 +116,7 @@ class WazuhCollector:
             )
         # Legacy Wazuh support (< v4.4)
         else:
-             metric.add_sample(
+            metric.add_sample(
                 "wazuh_active_agents",
                 value=agents["agent_status"]["active"],
                 labels={}

--- a/main.py
+++ b/main.py
@@ -89,25 +89,56 @@ class WazuhCollector:
         yield metric
         metric = Metric("wazuh_agent_status", "Total Wazuh agents by status", "summary")
 
-        metric.add_sample(
-            "wazuh_active_agents", value=agents["agent_status"]["connection"]["active"], labels={}
-        )
-        metric.add_sample(
-            "wazuh_disconnected_agents",
-            value=agents["agent_status"]["connection"]["disconnected"],
-            labels={},
-        )
-        metric.add_sample(
-            "wazuh_never_connected_agents",
-            value=agents["agent_status"]["connection"]["never_connected"],
-            labels={},
-        )
-        metric.add_sample(
-            "wazuh_pending_agents", value=agents["agent_status"]["connection"]["pending"], labels={}
-        )
-        metric.add_sample(
-            "wazuh_total_agents", value=agents["agent_status"]["connection"]["total"], labels={}
-        )
+        # Wazuh >= v4.4
+        if "connection" in agents["agent_status"]:
+            metric.add_sample(
+                "wazuh_active_agents",
+                value=agents["agent_status"]["connection"]["active"],
+                labels={}
+            )
+            metric.add_sample(
+                "wazuh_disconnected_agents",
+                value=agents["agent_status"]["connection"]["disconnected"],
+                labels={},
+            )
+            metric.add_sample(
+                "wazuh_never_connected_agents",
+                value=agents["agent_status"]["connection"]["never_connected"],
+                labels={},
+            )
+            metric.add_sample(
+                "wazuh_pending_agents", value=agents["agent_status"]["connection"]["pending"],
+                labels={}
+            )
+            metric.add_sample(
+                "wazuh_total_agents", value=agents["agent_status"]["connection"]["total"],
+                labels={}
+            )
+        # Legacy Wazuh support (< v4.4)
+        else:
+             metric.add_sample(
+                "wazuh_active_agents",
+                value=agents["agent_status"]["active"],
+                labels={}
+            )
+            metric.add_sample(
+                "wazuh_disconnected_agents",
+                value=agents["agent_status"]["disconnected"],
+                labels={},
+            )
+            metric.add_sample(
+                "wazuh_never_connected_agents",
+                value=agents["agent_status"]["never_connected"],
+                labels={},
+            )
+            metric.add_sample(
+                "wazuh_pending_agents", value=agents["agent_status"]["pending"],
+                labels={}
+            )
+            metric.add_sample(
+                "wazuh_total_agents", value=agents["agent_status"]["total"],
+                labels={}
+            )
         yield metric
         metric = InfoMetricFamily("wazuh_agent_version", "Wazuh agent versions")
         for version in agents["agent_version"]:

--- a/main.py
+++ b/main.py
@@ -91,54 +91,36 @@ class WazuhCollector:
 
         # Wazuh >= v4.4
         if "connection" in agents["agent_status"]:
-            metric.add_sample(
-                "wazuh_active_agents",
-                value=agents["agent_status"]["connection"]["active"],
-                labels={}
-            )
-            metric.add_sample(
-                "wazuh_disconnected_agents",
-                value=agents["agent_status"]["connection"]["disconnected"],
-                labels={},
-            )
-            metric.add_sample(
-                "wazuh_never_connected_agents",
-                value=agents["agent_status"]["connection"]["never_connected"],
-                labels={},
-            )
-            metric.add_sample(
-                "wazuh_pending_agents", value=agents["agent_status"]["connection"]["pending"],
-                labels={}
-            )
-            metric.add_sample(
-                "wazuh_total_agents", value=agents["agent_status"]["connection"]["total"],
-                labels={}
-            )
+            agents_path = agents["agent_status"]["connection"]
         # Legacy Wazuh support (< v4.4)
         else:
-            metric.add_sample(
-                "wazuh_active_agents",
-                value=agents["agent_status"]["active"],
-                labels={}
-            )
-            metric.add_sample(
-                "wazuh_disconnected_agents",
-                value=agents["agent_status"]["disconnected"],
-                labels={},
-            )
-            metric.add_sample(
-                "wazuh_never_connected_agents",
-                value=agents["agent_status"]["never_connected"],
-                labels={},
-            )
-            metric.add_sample(
-                "wazuh_pending_agents", value=agents["agent_status"]["pending"],
-                labels={}
-            )
-            metric.add_sample(
-                "wazuh_total_agents", value=agents["agent_status"]["total"],
-                labels={}
-            )
+            agents_path = agents["agent_status"]
+        
+        metric.add_sample(
+            "wazuh_active_agents",
+            value=agents_path["active"],                
+            labels={}
+        )
+        metric.add_sample(
+           "wazuh_disconnected_agents",
+            value=agents_path["disconnected"],
+            labels={},
+        )
+        metric.add_sample(
+            "wazuh_never_connected_agents",
+            value=agents_path["never_connected"],
+            labels={},
+        )
+        metric.add_sample(
+            "wazuh_pending_agents",
+            value=agents_path["pending"],
+            labels={}
+        )
+        metric.add_sample(
+            "wazuh_total_agents",
+            value=agents_path["total"],
+            labels={}
+        )
         yield metric
         metric = InfoMetricFamily("wazuh_agent_version", "Wazuh agent versions")
         for version in agents["agent_version"]:

--- a/main.py
+++ b/main.py
@@ -90,23 +90,23 @@ class WazuhCollector:
         metric = Metric("wazuh_agent_status", "Total Wazuh agents by status", "summary")
 
         metric.add_sample(
-            "wazuh_active_agents", value=agents["agent_status"]["active"], labels={}
+            "wazuh_active_agents", value=agents["agent_status"]["connection"]["active"], labels={}
         )
         metric.add_sample(
             "wazuh_disconnected_agents",
-            value=agents["agent_status"]["disconnected"],
+            value=agents["agent_status"]["connection"]["disconnected"],
             labels={},
         )
         metric.add_sample(
             "wazuh_never_connected_agents",
-            value=agents["agent_status"]["never_connected"],
+            value=agents["agent_status"]["connection"]["never_connected"],
             labels={},
         )
         metric.add_sample(
-            "wazuh_pending_agents", value=agents["agent_status"]["pending"], labels={}
+            "wazuh_pending_agents", value=agents["agent_status"]["connection"]["pending"], labels={}
         )
         metric.add_sample(
-            "wazuh_total_agents", value=agents["agent_status"]["total"], labels={}
+            "wazuh_total_agents", value=agents["agent_status"]["connection"]["total"], labels={}
         )
         yield metric
         metric = InfoMetricFamily("wazuh_agent_version", "Wazuh agent versions")


### PR DESCRIPTION
As of the new version of Wazuh (v4.4), the returned JSON by `/overview/agents` appears to have changed to be the following:
```
      "agent_status" : {
         "configuration" : {
            "synced" : X,
            "not_synced" : X,
            "total" : X
         },
         "connection" : {
            "disconnected" : X,
            "pending" : X,
            "total" : X,
            "active" : X,
            "never_connected" : X
         }
      }
```
Which is causing accesses like `agents["agent_status"]["active"]` to fail and throw a KeyError, e.g.:
```
Traceback (most recent call last):
  File "./main.py", line 540, in <module>
    REGISTRY.register(WazuhCollector())
  File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 40, in register
    names = self._get_names(collector)
  File "/usr/local/lib/python3.8/site-packages/prometheus_client/registry.py", line 80, in _get_names
    for metric in desc_func():
  File "./main.py", line 93, in collect
    "wazuh_active_agents", value=agents["agent_status"]["active"], labels={}
KeyError: 'active'
```

This PR addresses this by adding the connective JSON property "connection" to such accesses (e.g., `agents["agent_status"]["connection"]["active"]`).