### PR TITLE
Tune some metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ Simple prometheus exporter for Wazuh server
 
 ## System environments
 
-| Name                  | Description                                           |
-|-----------------------|-------------------------------------------------------|
-| WAZUH_API_HOST        | Wazuh API host e.g `127.0.0.1` or `wazuh`             |
-| WAZUH_API_PORT        | Wazuh API port e.g `55000`                            |
-| WAZUH_API_USERNAME    | Wazuh API user for authorization                      |
-| WAZUH_API_PASSWORD    | Wazuh API user password for authorization             |
-| EXPORTER_PORT         | Exporter listen port, default 5000                    |
-| EXPORTER_LOG_LEVEL    | Exporter log level, default INFO, for debug use DEBUG |
+| Name                       | Description                                           |
+|----------------------------|-------------------------------------------------------|
+| WAZUH_API_HOST             | Wazuh API host e.g `127.0.0.1` or `wazuh`             |
+| WAZUH_API_PORT             | Wazuh API port e.g `55000`                            |
+| WAZUH_API_USERNAME         | Wazuh API user for authorization                      |
+| WAZUH_API_PASSWORD         | Wazuh API user password for authorization             |
+| EXPORTER_PORT              | Exporter listen port, default 5000                    |
+| EXPORTER_LOG_LEVEL         | Exporter log level, default INFO, for debug use DEBUG |
+| SKIP_LAST_LOGS             | If set skip metrics last_logs_info                    |
+| SKIP_LAST_REGISTERED_AGENT | If set skip metrics last_registered_agent_info        |
+| SKIP_WAZUH_API_INFO        | if set skip metrics wazuh_api_info                    |
 
 ## Deployment
 

--- a/main.py
+++ b/main.py
@@ -145,14 +145,14 @@ class WazuhCollector:
             labels={},
         )
         yield metric
-        metric = InfoMetricFamily("nodes_healthcheck", "Wazuh nodes healthcheck")
+        metric = InfoMetricFamily("nodes_healthcheck", "Wazuh nodes healthcheck", labels=["node_name"])
         nodes = wazuh_connection.wazuh_get_nodes_healtchecks(auth)
         if nodes is not None:
             for node in nodes:
-                for key, value in node["info"].items():
-                    metric.add_metric(
-                        labels=node["info"]["name"], value={f"{key}": f"{value}"}
-                    )
+                infos = { k:str(v) for (k, v) in node["info"].items() if k != "name" and k!= "n_active_agents" }
+                metric.add_metric(
+                    labels=[node["info"]["name"]], value=infos
+                )
             yield metric
 
         info = wazuh_connection.wazuh_api_info(auth)

--- a/main.py
+++ b/main.py
@@ -64,11 +64,11 @@ class WazuhCollector:
         validate_configuration = wazuh_connection.wazuh_validate_configuration(auth)
         metric = Metric("wazuh_total_agent", "Total Wazuh agents count", "summary")
         for agent in agents["nodes"]:
-            metric.add_sample("wazuh_agents_count", value=agent["count"], labels={})
+            metric.add_sample("wazuh_agents_count", value=agent["count"], labels={"node_name": agent["node_name"]})
         yield metric
         metric = Metric("wazuh_total_group", "Total Wazuh groups count", "summary")
         for group in agents["groups"]:
-            metric.add_sample("wazuh_agents_group", value=group["count"], labels={})
+            metric.add_sample("wazuh_agents_group", value=group["count"], labels={"group_name": group["name"]})
         yield metric
         metric = Metric("wazuh_agent_status", "Total Wazuh agents by status", "summary")
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import logging
 import time
 
 from prometheus_client import start_http_server, Metric, REGISTRY
-from prometheus_client.metrics_core import InfoMetricFamily
+from prometheus_client.metrics_core import InfoMetricFamily, GaugeMetricFamily
 
 import wazuh
 
@@ -96,11 +96,11 @@ class WazuhCollector:
         )
         metric.add_sample("wazuh_total_agents", value=agents_path["total"], labels={})
         yield metric
-        metric = InfoMetricFamily("wazuh_agent_version", "Wazuh agent versions")
+        metric = GaugeMetricFamily("wazuh_agent_version", "Wazuh agent versions", labels=["version"])
         for version in agents["agent_version"]:
             metric.add_metric(
-                labels="version",
-                value={"version": version["version"], "count": str(version["count"])},
+                labels=[version["version"]],
+                value=version["count"],
             )
 
         yield metric


### PR DESCRIPTION
This PR add a bunch of changes to metrics : 

- add some environment variables to disable some metrics which might not be useful to everybody and/or add too many cardinality (https://github.com/pyToshka/wazuh-prometheus-exporter/issues/27)
- add node name and group name to wazuh_agents_* metrics (#29)
- expose nodes_healthcheck as one metric for each node
- switch wazuh_agent_version to gauge so that the number of agent per Wazuh version is exploitable as a prometheus metric

If needed I can split this PR in multiple ones.