### PR TITLE
correct SemVer version comparison to prevent issue with 4.10

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ class WazuhCollector:
                 value=remote_state["discarded_count"],
                 labels={"manager_stats_remote": "discarded_count"},
             )
-            if info.get("api_version") < "4.7.0":
+            if tuple(map(int, (info.get("api_version").split(".")))) < (4,7,0):
                 metric.add_sample(
                     "queued_msgs",
                     value=remote_state["queued_msgs"],
@@ -266,7 +266,7 @@ class WazuhCollector:
                 value=analysisd_stat["syscheck_events_decoded"],
                 labels={"analysisd_stats": "syscheck_events_decoded"},
             )
-            if info.get("api_version") < "4.7.0":
+            if tuple(map(int, (info.get("api_version").split(".")))) < (4,7,0):
                 metric.add_sample(
                     "analysisd_stats",
                     value=analysisd_stat["syscheck_edps"],


### PR DESCRIPTION
Closes #36.

Thanks a ton for the great project 🙇 

While giving it a try, I stumbled over the same issue reported in #36 with a Wazuh 4.10 instance. It seems that the current version gate doesn't correctly handle semantic versions, so `4.10` is treated as lower than `4.7`, hence the exporter fails to start. Converting both versions into tuples and comparing them that way solves the issue while also not introducing any additional dependencies. Using the same overwriting workaround as mentioned in #36 with the changes here worked without issues.

/cc @pyToshka 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved version comparison logic for metrics collection.
	- Enhanced reliability of version-based conditional checks in the application.
- **New Features**
	- Added support for semantic versioning comparisons in API version checks.
- **Chores**
	- Updated dependencies to include `packaging==24.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->